### PR TITLE
np.int deprecated in numpy versions beyond 1.20, changed to np.int32

### DIFF
--- a/iglu_datasets/task.py
+++ b/iglu_datasets/task.py
@@ -173,7 +173,7 @@ class Tasks:
         """
         if isinstance(blocks, (list, tuple)):
             if all(isinstance(b, (list, tuple)) for b in blocks):
-                grid = np.zeros(BUILD_ZONE_SIZE, dtype=np.int)
+                grid = np.zeros(BUILD_ZONE_SIZE, dtype=np.int32)
                 for x, y, z, block_id in blocks:
                     grid[y + 1, x + BUILD_ZONE_SIZE_X // 2, z + BUILD_ZONE_SIZE_Z // 2] = block_id
                 blocks = grid


### PR DESCRIPTION
requirements.txt file specifies latest numpy version. 
When running, an error occurs as np.int, referred to in task.py, has been deprecated in versions > 1.20.

This patch changes the instance of np.int to np.int32, resolving the issue.  The alternative would be to fix the numpy version (<=1.20).